### PR TITLE
[PASMS-5] PET, PET_DOCUMENT, ADOPTION DDL have been created

### DIFF
--- a/src/be-src/src/main/java/db_proj_be/SQL/pasms_ddl.sql
+++ b/src/be-src/src/main/java/db_proj_be/SQL/pasms_ddl.sql
@@ -84,7 +84,7 @@ BEGIN
 
 CREATE TABLE PET_DOCUMENT (
     id INT IDENTITY(1, 1) PRIMARY KEY,
-    pet_id INT FOREIGN KEY REFERENCES PET(id),
+    pet_id INT NOT NULL FOREIGN KEY REFERENCES PET(id),
     document_type VARCHAR(50) NOT NULL,
     document VARBINARY(MAX) NOT NULL
 );
@@ -101,7 +101,7 @@ IF dbo.relation_exists(@inputTableName) = 0
 BEGIN
 
 CREATE TABLE ADOPTION (
-    pet_id INT FOREIGN KEY REFERENCES PET(id),
+    pet_id INT NOT NULL FOREIGN KEY REFERENCES PET(id),
     adopter_id INT,
     PRIMARY KEY (pet_id, adopter_id)
 );


### PR DESCRIPTION
The **PET**, **PET_DOCUMENT**, **ADOPTION** relations have been created.

### CHANGES:

1. An attribute `vaccination` with data type **BIT** has been added to relation **PET**. Based on our last conversation, to add this boolean attribute to the relation and remove the relation **VACCINATION**.
2. The data type of `document` is changed from **BLOB** to be **VARBINARY(MAX)**.
3. Renaming the primary key of the relation from `relationName_id` to `id`.

### NOTES:

1. Foreign key of `shelter_id` in **PET** relation: I assumed that the relation that referenced will named `SHELTER` having primary key `id`.
2. Foreign key of `adopter_id` in **ADOPTION** relation: I assumed that the relation that referenced will named `ADOPTER` having primary key `id`.