### PR TITLE
Ddl adoption notification

### DIFF
--- a/src/be-src/src/main/java/db_proj_be/SQL/pasms_ddl.sql
+++ b/src/be-src/src/main/java/db_proj_be/SQL/pasms_ddl.sql
@@ -204,7 +204,7 @@ BEGIN
         adopter_id INT NOT NULL,
         status BIT NOT NULL, -- equivalent to isRead
         date DATE NOT NULL,
-        PRIMARY KEY (application_id, adopter_id),
+        PRIMARY KEY (application_id),
         FOREIGN KEY (application_id) REFERENCES ADOPTION_APPLICATION(id),
         FOREIGN KEY (adopter_id) REFERENCES ADOPTER(id)
     );


### PR DESCRIPTION
Modified `APPLICATION_NOTIFICATION` relation with the following:
- Renamed `adoption_application_id` to `application_id` .
- Set primary key as `application_id` only instead of composite key `(application_id, adopter_id)` since `application_id` is globally unique.