### PR TITLE
[PASMS-57] Refactored the Adopter component (sign in / sign up forms).

### DIFF
--- a/src/fe-src/src/app/Components/adopter/adopter.component.css
+++ b/src/fe-src/src/app/Components/adopter/adopter.component.css
@@ -1,9 +1,3 @@
-.container {
-  max-width: 800px;
-  margin: 10px;
-  padding: 5px;
-}
-
 h2 {
   margin-bottom: 20px;
   text-align: center;
@@ -15,19 +9,20 @@ h2 {
   margin-bottom: 100px;
 }
 
-.form-group {
-  padding: 5px;
+.center {
+  width: 100%;
+}
+
+.formGroup {
   display: flex;
   flex-direction: column;
-  margin-bottom: 10px; /* Adjust as needed for spacing between form groups */
-  max-width: 500px; /* Set a maximum width for the form groups */
+  max-width: 500px;
   width: 50%;
   padding: 20px;
-  margin: 5px auto;
+  margin: 0 auto 20px;
   background-color: var(--beige);
   border-radius: 5px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  min-height: 250px;
 }
 
 label {
@@ -35,15 +30,6 @@ label {
   font-weight: bold;
   margin-bottom: 5px;
   margin-top: 5px;
-}
-
-input[type="text"],
-textarea {
-  width: 100%;
-  padding: 8px;
-  box-sizing: border-box;
-  background-color: beige;
-  font-family: 'Montserrat', sans-serif;
 }
 
 input[type="checkbox"] {
@@ -61,6 +47,7 @@ button {
   align-self: center;
   margin-left: 50%;
   transform: translate(-50%);
+  margin-top: 5px;
 }
 
 button:disabled {
@@ -68,14 +55,11 @@ button:disabled {
   cursor: not-allowed;
 }
 
-label {
-  margin-bottom: 5px; /* Adjust as needed for spacing between label and input */
-}
-
 input {
   width: 100%; /* Force the input fields to take full width within their container */
   box-sizing: border-box; /* Include padding and border within the width */
   padding: 5px;
+  margin-bottom: 5px;
 }
 
 .input-error {

--- a/src/fe-src/src/app/Components/adopter/adopter.component.css
+++ b/src/fe-src/src/app/Components/adopter/adopter.component.css
@@ -248,3 +248,6 @@ input {
   margin-top: 5px;
 }
 
+option {
+  font-size: 15px;
+}

--- a/src/fe-src/src/app/Components/adopter/adopter.component.html
+++ b/src/fe-src/src/app/Components/adopter/adopter.component.html
@@ -10,7 +10,7 @@
       <form class="glbFormGroup" [formGroup]="signInForm" (ngSubmit)="signIn()">
         <div>
           <label class="glbLabel" for="email">Email</label>
-          <input class="glbInput" type="email" id="email" formControlName="email" required />
+          <input class="glbInput" type="email" id="email" formControlName="email" placeholder="john.doe@example.com" required />
         </div>
         <div>
           <label class="glbLabel" for="password">Password:</label>
@@ -46,11 +46,18 @@
         </div>
         <div>
           <label class="glbLabel" for="birthDate">Birth Date</label>
-          <input class="glbInput" type="text" id="birthDate" formControlName="birthDate" required />
+          <input class="glbInput" type="date" id="birthDate" formControlName="birthDate" required />
+<!--          <input class="glbInput" type="text" id="birthDate" formControlName="birthDate" required />-->
         </div>
         <div>
           <label class="glbLabel" for="gender">Gender</label>
-          <input class="glbInput" type="text" id="gender" formControlName="gender" required />
+<!--          <input class="glbInput" type="text" id="gender" formControlName="gender" required />-->
+          <select class="glbInput" id="gender" formControlName="gender" required>
+            <!-- Male option -->
+            <option value="male">Male</option>
+            <!-- Female option -->
+            <option value="female">Female</option>
+          </select>
         </div>
         <div>
           <label class="glbLabel" for="address">Address</label>

--- a/src/fe-src/src/app/Components/adopter/adopter.component.html
+++ b/src/fe-src/src/app/Components/adopter/adopter.component.html
@@ -4,57 +4,60 @@
 
   <ng-container *ngIf="adopter == null; else loggedIn">
     <div class="center">
+
       <h2>Adopter Sign In</h2>
-      <form class="formGroup" [formGroup]="signInForm" (ngSubmit)="signIn()">
+
+      <form class="glbFormGroup" [formGroup]="signInForm" (ngSubmit)="signIn()">
         <div>
-          <label for="email">Email</label>
-          <input type="email" id="email" formControlName="email" required />
+          <label class="glbLabel" for="email">Email</label>
+          <input class="glbInput" type="email" id="email" formControlName="email" required />
         </div>
         <div>
-          <label for="password">Password:</label>
-          <input type="password" id="password" formControlName="password" placeholder="Enter your password" required>
+          <label class="glbLabel" for="password">Password:</label>
+          <input class="glbInput" type="password" id="password" formControlName="password" placeholder="Enter your password" required>
         </div>
         <div>
-          <button type="submit" [disabled]="!signInForm.valid">Sign In</button>
+          <button class="glbButton" type="submit" [disabled]="!signInForm.valid">Sign In</button>
         </div>
       </form>
 
+      <h2>Adopter Sign Up</h2>
 
-      <form class="formGroup" [formGroup]="signUpForm" (ngSubmit)="signUp()">
+      <form class="glbFormGroup" [formGroup]="signUpForm" (ngSubmit)="signUp()">
         <div>
-          <label for="firstName">First Name</label>
-          <input type="text" id="firstName" formControlName="firstName" required />
+          <label class="glbLabel" for="firstName">First Name</label>
+          <input class="glbInput" type="text" id="firstName" formControlName="firstName" required />
         </div>
         <div>
-          <label for="lastName">Last Name</label>
-          <input type="text" id="lastName" formControlName="lastName" required />
+          <label class="glbLabel" for="lastName">Last Name</label>
+          <input class="glbInput" type="text" id="lastName" formControlName="lastName" required />
         </div>
         <div>
-          <label for="emailSignUp">Email</label>
-          <input type="email" id="emailSignUp" formControlName="email" required />
+          <label class="glbLabel" for="emailSignUp">Email</label>
+          <input class="glbInput" type="email" id="emailSignUp" formControlName="email" required />
         </div>
         <div>
-          <label for="phone">Phone</label>
-          <input type="text" id="phone" formControlName="phone" />
+          <label class="glbLabel" for="phone">Phone</label>
+          <input class="glbInput" type="text" id="phone" formControlName="phone" />
         </div>
         <div>
-          <label for="passwordSignUp">Password</label>
-          <input type="password" id="passwordSignUp" formControlName="password" required />
+          <label class="glbLabel" for="passwordSignUp">Password</label>
+          <input class="glbInput" type="password" id="passwordSignUp" formControlName="password" required />
         </div>
         <div>
-          <label for="birthDate">Birth Date</label>
-          <input type="text" id="birthDate" formControlName="birthDate" required />
+          <label class="glbLabel" for="birthDate">Birth Date</label>
+          <input class="glbInput" type="text" id="birthDate" formControlName="birthDate" required />
         </div>
         <div>
-          <label for="gender">Gender</label>
-          <input type="text" id="gender" formControlName="gender" required />
+          <label class="glbLabel" for="gender">Gender</label>
+          <input class="glbInput" type="text" id="gender" formControlName="gender" required />
         </div>
         <div>
-          <label for="address">Address</label>
-          <input type="text" id="address" formControlName="address" required />
+          <label class="glbLabel" for="address">Address</label>
+          <input class="glbInput" type="text" id="address" formControlName="address" required />
         </div>
         <div>
-          <button type="submit" [disabled]="!signUpForm.valid">Sign Up</button>
+          <button class="glbButton" type="submit" [disabled]="!signUpForm.valid">Sign Up</button>
         </div>
       </form>
 
@@ -150,7 +153,7 @@
                 <!-- Display other notification details as needed -->
               </li>
             </ul>
-          
+
             <h2>Pet Availability Notifications</h2>
             <ul class="not-list">
               <li *ngFor="let notification of petAvailabilityNotifications" (click)="currentSection = 0">

--- a/src/fe-src/src/app/Components/adopter/adopter.component.ts
+++ b/src/fe-src/src/app/Components/adopter/adopter.component.ts
@@ -1,14 +1,13 @@
-import { PetAvailabilityNotification } from './../../Entities/PetAvailabilityNotification';
-import { ApplicationNotification } from './../../Entities/ApplicationNotification';
-import { AdoptionApplication } from './../../Entities/AdoptionApplication';
+import { PetAvailabilityNotification } from '../../Entities/PetAvailabilityNotification';
+import { ApplicationNotification } from '../../Entities/ApplicationNotification';
+import { AdoptionApplication } from '../../Entities/AdoptionApplication';
 import { HttpClient } from '@angular/common/http';
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ApplicationStatus } from 'src/app/Entities/ApplicationStatus';
 import { AdopterServicesService } from 'src/app/Services/adopter-services.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import {UtilitiesService} from "../../Services/utilities.service";
-import {Admin} from "../../Entities/Admin";
 import {Adopter} from "../../Entities/Adopter";
 
 
@@ -136,8 +135,11 @@ export class AdopterComponent implements OnInit{
     const lastName = this.signUpForm.get('lastName')?.value;
     const phone = this.signUpForm.get('phone')?.value;
     const birthDate = this.signUpForm.get('birthDate')?.value;
-    const gender = this.signUpForm.get('gender')?.value;
+    const gender = (this.signUpForm.get('gender')?.value) === "male";
     const address = this.signUpForm.get('address')?.value;
+
+    console.log(birthDate)
+    console.log(gender)
 
 
     let tempAdopter = new Adopter(undefined, firstName, lastName, email, phone, password, birthDate, gender, address);

--- a/src/fe-src/src/styles.css
+++ b/src/fe-src/src/styles.css
@@ -28,3 +28,49 @@ body::-webkit-scrollbar-thumb {
 body::-webkit-scrollbar-track {
   background-color: var(--beige);
 }
+
+.glbFormGroup {
+  display: flex;
+  flex-direction: column;
+  max-width: 500px;
+  width: 50%;
+  padding: 20px;
+  margin: 0 auto 20px;
+  background-color: var(--beige);
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.glbLabel {
+  display: flex;
+  font-weight: bold;
+  margin-bottom: 5px;
+  margin-top: 5px;
+}
+
+.glbButton {
+  padding: 10px 25px;
+  background-color: var(--dark-brown);
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  align-self: center;
+  margin-left: 50%;
+  transform: translate(-50%);
+  margin-top: 5px;
+}
+
+.glbButton:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.glbInput {
+  width: 100%; /* Force the input fields to take full width within their container */
+  box-sizing: border-box; /* Include padding and border within the width */
+  padding: 5px;
+  margin-bottom: 5px;
+}
+


### PR DESCRIPTION
# Introduction
Modified the CSS of the Sign Up / Sign In forms of the Adopter component, to match and be consistent with the previous forms already developed.

# Details
Modified the CSS file, in which I've removed the unnecessary styling (either was duplicated, not used or overwritten). I've also used global styling instead, that's why you will find a set of styling added to the global CSS file to style the sign in / sign up forms using the same CSS. The global CSS classes made have a **_"glb"_** prefix, which stands for "global".

Q: "Since you have already used global CSS styling, why didn't you remove them from the component CSS file ??"
A: Due to the presence of subpages in that component that still use this CSS.

# Attachments
![image](https://github.com/GeorgeBeshay/db-project/assets/90455303/237095bb-1487-4120-93d5-3fcfd272a026)
![image](https://github.com/GeorgeBeshay/db-project/assets/90455303/d1021635-d2b4-4041-895b-e7c0991c88b8)
