### PR TITLE
[Pasms 69] REF Adoption Application DAO Tests

### DIFF
--- a/src/be-src/src/main/java/db_proj_be/Database/DAOs/AdoptionApplicationDAO.java
+++ b/src/be-src/src/main/java/db_proj_be/Database/DAOs/AdoptionApplicationDAO.java
@@ -8,7 +8,6 @@ import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Date;
 import java.util.List;
 
 public class AdoptionApplicationDAO extends DAO<AdoptionApplication> {
@@ -28,18 +27,6 @@ public class AdoptionApplicationDAO extends DAO<AdoptionApplication> {
             return jdbcTemplate.query(sql, getRowMapper(), status.getValue());
         } catch (Exception ex) {
             Logger.logMsgFrom(this.getClass().getName(), "Error in ADOPTION_APPLICATION findByStatus(): " + ex.getMessage(), 1);
-            return null;
-        }
-    }
-
-    // Return all records with the given creation date
-    @Transactional
-    public List<AdoptionApplication> findByDateCreated(Date date) {
-        try {
-            String sql = "SELECT * FROM ADOPTION_APPLICATION WHERE date = ?";
-            return jdbcTemplate.query(sql, getRowMapper(), date);
-        } catch (Exception ex) {
-            Logger.logMsgFrom(this.getClass().getName(), "Error in ADOPTION_APPLICATION findByDateCreated(): " + ex.getMessage(), 1);
             return null;
         }
     }
@@ -75,7 +62,7 @@ public class AdoptionApplicationDAO extends DAO<AdoptionApplication> {
         if (adoptionApplication == null) {
             throw new IllegalArgumentException("Can't update an entity given a null object ..");
         }
-        
+
         try {
             String sql = "UPDATE ADOPTION_APPLICATION SET " +
                     "adopter_id = ?, " +

--- a/src/be-src/src/test/java/db_proj_be/Database/DAOs/AdoptionApplicationDAOTests.java
+++ b/src/be-src/src/test/java/db_proj_be/Database/DAOs/AdoptionApplicationDAOTests.java
@@ -249,7 +249,7 @@ public class AdoptionApplicationDAOTests {
     @Test
     public void testAdoptionApplicationUpdatingValidObject() {
         // Arrange
-        int adopterId = this.createAdopter("john.Doe5@example.com");
+        int adopterId = this.createAdopter("john.Doe20@example.com");
         int petId = this.createPet();
         ApplicationStatus status = ApplicationStatus.PENDING;
         String description = "I need to adopt this pet.";
@@ -284,6 +284,7 @@ public class AdoptionApplicationDAOTests {
         assertEquals(fetchedAdoptionApp.getClosingDate(), closingDate);
 
         // clean
+        jdbcTemplate.update("DELETE FROM APPLICATION_NOTIFICATION WHERE application_id = ?", id);
         jdbcTemplate.update("DELETE FROM ADOPTION_APPLICATION WHERE id = ?", id);
         jdbcTemplate.update("DELETE FROM ADOPTER WHERE id = ?", adopterId);
         jdbcTemplate.update("DELETE FROM PET WHERE id = ?", petId);


### PR DESCRIPTION
- While attempting to increase the test coverage of the `AdoptionApplicationDAO` class, I found that the only method not covered  within the test cases is the method `findByDateCreated()` but this method is unused at all in the whole program. So, I found it more convenient to remove this method which resulted in increased test coverage of the class (100% methods, 72% lines).

- Regarding the test case `testAdoptionApplicationUpdatingValidObject` which may fail when you run it, the reason of failure is that due to the trigger we implemented which automatically creates a notification record referencing the adoption application record whose status changes, we can't delete the adoption application record unless we delete the notification record referencing it first in order to not violate any integrity constraint. To solve this issue, I have added a line to delete the `APPLICATION_NOTIFICATION` record referencing the `ADOPTION_APPLICATION` record first before deleting the latter. As a result, the test case passed with no errors. 