### PR TITLE
[PASMS-61] Elevating the Admin API Test Coverage to 100%

### DIFF
--- a/src/be-src/src/main/java/db_proj_be/APIs/AdminAPI.java
+++ b/src/be-src/src/main/java/db_proj_be/APIs/AdminAPI.java
@@ -37,6 +37,7 @@ public class AdminAPI {
         return new ResponseEntity<>(resultAdminObject,
                 (resultAdminObject != null) ? HttpStatus.OK : HttpStatus.BAD_REQUEST);
     }
+
     @PostMapping("createShelter")
     @ResponseBody
     public ResponseEntity<Shelter> createShelter(@RequestBody Shelter shelterToBeCreated){
@@ -56,6 +57,7 @@ public class AdminAPI {
         Staff createdStaff = this.adminService.createStaff(staffToBeCreated);
         return new ResponseEntity<>(createdStaff, (createdStaff != null) ? HttpStatus.OK : HttpStatus.BAD_REQUEST);
     }
+
     @PostMapping("deleteShelter")
     @ResponseBody
     public ResponseEntity<Boolean> deleteShelter(@RequestBody Shelter shelterToBeDeleted){
@@ -63,10 +65,12 @@ public class AdminAPI {
         boolean result = this.adminService.deleteShelter(shelterToBeDeleted);
         return new ResponseEntity<>(result,(result) ? HttpStatus.OK:HttpStatus.BAD_REQUEST);
     }
+
     @PostMapping("findAllShelters")
     @ResponseBody
     public ResponseEntity<List<Shelter>> findAllShelters(){
         Logger.logMsgFrom(this.getClass().getName(),"Admin has requested to display all shelters.",0);
         return new ResponseEntity<>(this.adminService.findAllShelters(),HttpStatus.OK);
     }
+
 }

--- a/src/be-src/src/main/java/db_proj_be/BusinessLogic/EntityModels/Pet.java
+++ b/src/be-src/src/main/java/db_proj_be/BusinessLogic/EntityModels/Pet.java
@@ -1,10 +1,6 @@
 package db_proj_be.BusinessLogic.EntityModels;
 
-
-import org.springframework.data.relational.core.sql.In;
-
 import java.util.Objects;
-
 
 public class Pet implements Identifiable {
 
@@ -152,10 +148,10 @@ public class Pet implements Identifiable {
         Pet pet = (Pet) o;
         return id == pet.id &&
                 gender == pet.gender &&
-                shelterId == pet.shelterId &&
                 neutering == pet.neutering &&
                 houseTraining == pet.houseTraining &&
                 vaccination == pet.vaccination &&
+                Objects.equals(shelterId, pet.shelterId) &&
                 Objects.equals(name, pet.name) &&
                 Objects.equals(specie, pet.specie) &&
                 Objects.equals(breed, pet.breed) &&

--- a/src/be-src/src/main/java/db_proj_be/BusinessLogic/Services/AdminService.java
+++ b/src/be-src/src/main/java/db_proj_be/BusinessLogic/Services/AdminService.java
@@ -8,7 +8,6 @@ import db_proj_be.BusinessLogic.Utilities.Logger;
 import db_proj_be.Database.DAOs.AdminDAO;
 import db_proj_be.Database.DAOs.ShelterDAO;
 import db_proj_be.Database.DAOs.StaffDAO;
-import org.apache.juli.logging.Log;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -104,6 +103,7 @@ public class AdminService {
         Logger.logMsgFrom(this.getClass().getName(), "Something had went wrong ..", 1);
         return null;
     }
+
     public Shelter createShelter(Shelter shelter) {
         if(shelter == null){
             Logger.logMsgFrom(this.getClass().getName(),"Shelter creation failed .. shelter object sent is null",1);
@@ -115,17 +115,15 @@ public class AdminService {
             return null;
         }
         Shelter createdShelter = this.shelterDAO.findById(createdShelterId);
-        if(createdShelter != null){
-            Logger.logMsgFrom(this.getClass().getName(),"Created a shelter record with id "+createdShelterId + " successfully. ",0);
-            return createdShelter;
-        }
-        Logger.logMsgFrom(this.getClass().getName(),"Something went wrong .. ",1);
-        return null;
+        Logger.logMsgFrom(this.getClass().getName(),"Created a shelter record with id " + createdShelterId + " successfully. ",0);
+        return createdShelter;
     }
+
     public List<Shelter> findAllShelters(){
         Logger.logMsgFrom(this.getClass().getName(),"Admin has requested to get all system shelters .. processing the request .. ",0);
         return this.shelterDAO.findAll();
     }
+
     public boolean deleteShelter(Shelter shelter){
         if(shelter == null ){
             Logger.logMsgFrom(this.getClass().getName(),"Shelter object to be deleted was sent null",1);
@@ -134,8 +132,10 @@ public class AdminService {
         Logger.logMsgFrom(this.getClass().getName(),"Admin has requested to deleter shelter with id: "+shelter.getId()+" processing the request .. ",0);
         return this.shelterDAO.delete(shelter);
     }
+
     public boolean deleteShelterByName(String name){
         Logger.logMsgFrom(this.getClass().getName(),"Admin has requested to deleter shelter with id: "+name+" processing the request .. ",0);
         return this.shelterDAO.deleteByName(name);
     }
+
 }

--- a/src/be-src/src/test/java/db_proj_be/APIs/AdminAPITests.java
+++ b/src/be-src/src/test/java/db_proj_be/APIs/AdminAPITests.java
@@ -1,5 +1,6 @@
 package db_proj_be.APIs;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import db_proj_be.BusinessLogic.EntityModels.Admin;
 import db_proj_be.BusinessLogic.EntityModels.Shelter;
 import db_proj_be.BusinessLogic.EntityModels.Staff;
@@ -8,6 +9,7 @@ import db_proj_be.BusinessLogic.Utilities.Hasher;
 import db_proj_be.Database.DAOs.AdminDAO;
 import db_proj_be.Database.DAOs.ShelterDAO;
 import db_proj_be.besrc.BeSrcApplication;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -20,6 +22,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -230,6 +234,333 @@ public class AdminAPITests {
         // Clean
         assertEquals(1, jdbcTemplate.update("DELETE FROM STAFF WHERE id = ?", staffId));
         assertEquals(1, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId));
+    }
+
+    @Test
+    @Disabled("Useless, not reaching the API actually.")
+    @DisplayName("Admin Creating Shelter - Null Shelter")
+    public void testCreateNullShelter() throws Exception {
+        // Act
+        MvcResult result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(null)))
+                .andReturn();
+
+        // Retrieve the response status code
+        int status = result.getResponse().getStatus();
+
+        // Assert the status code
+        assertEquals("", result.getResponse().getContentAsString());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), status);
+    }
+
+    @Test
+    @DisplayName("Admin Creating Shelter - Valid Creation")
+    public void testCreateValidShelter() throws Exception {
+        // Arrange
+        int shelterId;
+        String shelterName = "SHELTER X";
+        String shelterLocation = "SHELTER X LOCATION";
+        String shelterPhone = "123456789";
+        String shelterEmail = "shelterX@testmail.com";
+
+        Shelter shelter = new Shelter();
+        shelter.setName(shelterName);
+        shelter.setLocation(shelterLocation);
+        shelter.setPhone(shelterPhone);
+        shelter.setEmail(shelterEmail);
+
+        // Act
+        MvcResult result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        int status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Shelter resultShelter = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Shelter.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(resultShelter);
+        shelterId = resultShelter.getId();
+        shelter.setId(shelterId);
+        assertEquals(shelter, resultShelter);
+
+        // Clean
+        assertEquals(1, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId));
+    }
+
+    @Test
+    @DisplayName("Admin Creating Shelter - Invalid Duplicate Creation")
+    public void testCreateInvalidDuplicateShelter() throws Exception {
+        // Arrange
+        int shelterId;
+        String shelterName = "SHELTER X";
+        String shelterLocation = "SHELTER X LOCATION";
+        String shelterPhone = "123456789";
+        String shelterEmail = "shelterX@testmail.com";
+
+        Shelter shelter = new Shelter();
+        shelter.setName(shelterName);
+        shelter.setLocation(shelterLocation);
+        shelter.setPhone(shelterPhone);
+        shelter.setEmail(shelterEmail);
+
+        // Act
+        MvcResult result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        int status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Shelter resultShelter = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Shelter.class);
+
+        // Assert the status code and Admin object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(resultShelter);
+        shelterId = resultShelter.getId();
+        shelter.setId(shelterId);
+        assertEquals(shelter, resultShelter);
+
+        // Create a duplicate
+        result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        status = result.getResponse().getStatus();
+
+        // Assert the status code
+        assertEquals("", result.getResponse().getContentAsString());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), status);
+
+        // Clean
+        assertEquals(1, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId));
+    }
+
+    @Test
+    @DisplayName("Admin Finding All Shelters")
+    public void testFindAllShelters() throws Exception {
+        // Arrange
+        int shelterId;
+        String shelterName = "SHELTER X";
+        String shelterLocation = "SHELTER X LOCATION";
+        String shelterPhone = "123456789";
+        String shelterEmail = "shelterX@testmail.com";
+
+        Shelter shelter = new Shelter();
+        shelter.setName(shelterName);
+        shelter.setLocation(shelterLocation);
+        shelter.setPhone(shelterPhone);
+        shelter.setEmail(shelterEmail);
+
+        int shelterId2;
+        String shelterName2 = "SHELTER Y";
+        String shelterLocation2 = "SHELTER Y LOCATION";
+        String shelterPhone2 = "123456789";
+        String shelterEmail2 = "shelterY@testmail.com";
+
+        Shelter shelter2 = new Shelter();
+        shelter2.setName(shelterName2);
+        shelter2.setLocation(shelterLocation2);
+        shelter2.setPhone(shelterPhone2);
+        shelter2.setEmail(shelterEmail2);
+
+        // Act
+        MvcResult result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        int status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Shelter resultShelter = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Shelter.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(resultShelter);
+        shelterId = resultShelter.getId();
+        shelter.setId(shelterId);
+        assertEquals(shelter, resultShelter);
+
+        // Act
+        result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter2)))
+                .andReturn();
+
+        // Retrieve the response status code
+        status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        resultShelter = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Shelter.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(resultShelter);
+        shelterId2 = resultShelter.getId();
+        shelter2.setId(shelterId2);
+        assertEquals(shelter2, resultShelter);
+
+        // Act
+        result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/findAllShelters")
+                        .contentType(MediaType.APPLICATION_JSON)).andReturn();
+
+        // Retrieve the response status code
+        status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a list of shelters
+        List<Shelter> sheltersFound = new ObjectMapper().readValue(result.getResponse().getContentAsString(), new TypeReference<List<Shelter>>() {});
+
+
+        // Assert the status code and shelters found.
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(sheltersFound);
+        assertTrue(sheltersFound.size() >= 2);
+        assertTrue(sheltersFound.contains(shelter));
+        assertTrue(sheltersFound.contains(shelter2));
+
+        // Clean
+        assertEquals(1, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId));
+        assertEquals(1, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId2));
+    }
+
+    @Test
+    @DisplayName("Admin Deleting a Valid Shelter")
+    public void testDeleteValidShelter() throws Exception {
+        // Arrange
+        int shelterId;
+        String shelterName = "SHELTER X";
+        String shelterLocation = "SHELTER X LOCATION";
+        String shelterPhone = "123456789";
+        String shelterEmail = "shelterX@testmail.com";
+
+        Shelter shelter = new Shelter();
+        shelter.setName(shelterName);
+        shelter.setLocation(shelterLocation);
+        shelter.setPhone(shelterPhone);
+        shelter.setEmail(shelterEmail);
+
+        // Act
+        MvcResult result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        int status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Shelter resultShelter = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Shelter.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(resultShelter);
+        shelterId = resultShelter.getId();
+        shelter.setId(shelterId);
+        assertEquals(shelter, resultShelter);
+
+        // Act
+        result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/deleteShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Boolean deletionResult = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Boolean.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(deletionResult);
+        assertTrue(deletionResult);
+
+        // Clean
+        assertEquals(0, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId));
+    }
+
+    @Test
+    @DisplayName("Admin Deleting a Shelter - Invalid Deletion")
+    public void testDeleteInvalidShelter() throws Exception {
+        // Arrange
+        int shelterId;
+        String shelterName = "SHELTER X";
+        String shelterLocation = "SHELTER X LOCATION";
+        String shelterPhone = "123456789";
+        String shelterEmail = "shelterX@testmail.com";
+
+        Shelter shelter = new Shelter();
+        shelter.setName(shelterName);
+        shelter.setLocation(shelterLocation);
+        shelter.setPhone(shelterPhone);
+        shelter.setEmail(shelterEmail);
+
+        // Act
+        MvcResult result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/createShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        int status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Shelter resultShelter = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Shelter.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(resultShelter);
+        shelterId = resultShelter.getId();
+        shelter.setId(shelterId);
+        assertEquals(shelter, resultShelter);
+
+        // Act
+        result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/deleteShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        Boolean deletionResult = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Boolean.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.OK.value(), status);
+        assertNotNull(deletionResult);
+        assertTrue(deletionResult);
+
+        // Delete again (should fail)
+        result = mockMvc.perform(post("http://localhost:8081/pasms-server/admin-api/deleteShelter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(shelter)))
+                .andReturn();
+
+        // Retrieve the response status code
+        status = result.getResponse().getStatus();
+
+        // Retrieve the response content as a shelter object
+        deletionResult = new ObjectMapper().readValue(result.getResponse().getContentAsString(), Boolean.class);
+
+        // Assert the status code and shelter object
+        assertEquals(HttpStatus.BAD_REQUEST.value(), status);
+        assertNotNull(deletionResult);
+        assertFalse(deletionResult);
+
+        // Clean
+        assertEquals(0, jdbcTemplate.update("DELETE FROM SHELTER WHERE id = ?", shelterId));
     }
 
 }


### PR DESCRIPTION
### Notes

1. The `.equals()` method in the Pet class was modified to compare the field "shelterId" using the `Objects.equals()` method instead of the `==` operator, that's because the field type is the class `Integer` and not the primitive data type `int`. I'm not sure about that, but for some reason when the fields are compared using the '==' operator, the comparison fails, however, I understand that the instances of the class 'Integer' can still be compared using the '==' operator without any problems.

2. I've removed an execution path of the method `createShelter` in the _AdminService_ class that could never occur.
